### PR TITLE
Add TOML configuration file for formautofill l10n.

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+basepath = "."
+
+locales = [
+    "es-MX",
+]
+
+[env]
+    l = "{l10n_base}/locales/{locale}/"
+
+[[paths]]
+    reference = "locales/en-US/**"
+    l10n = "{l}**"


### PR DESCRIPTION
With this, you can just

```shell
pip install compare-locales
compare-locales l10n.toml .
```

to see the status.

You can even do

```shell
compare-locales -m ../merge l10n.toml .
````

to create merged files, with errors fixed.